### PR TITLE
Update html_table.jl, added type to table_html

### DIFF
--- a/src/html_table.jl
+++ b/src/html_table.jl
@@ -20,7 +20,7 @@ html_table(table_html)
 
 A DataFrame
 """
-function html_table(table_html::Vector{HTMLNode})::DataFrame
+function html_table(table_html::Union{Vector{HTMLNode}, HTMLElement{:table}})::DataFrame
     rows = html_elements(table_html, "tr")
     t = parse_rows.(rows)
     t = t[length.(t) .== length(t[1])]


### PR DESCRIPTION
If a webpage has multiple tables, users using Cascadia Selectors, such as Selector("table") will return an n-element Vector{HTMLNode}. The problem is the current implementation doesn't allow to loop through or broadcast the html_table function because the elements of the Vector{HTMLNode} are of type HTMLElement{:table}, so the function html_table function errors out as it expects type Vector{HTMLNode} not HTMLElement{:table}.

The proposed solution would alter the function by appending via Union the HTMLElement{:table} type to the table_html parameter. This allows users to broadcast the html_table function or loop through the elements of the tables vector and the html_table will return a vector of n dataframes.

```
using TidierVest
reponse = TidierVest.read_html("https://en.wikipedia.org/wiki/Houston")

# returns 23-element Vector{HTMLNode}
tables = TidierVest.html_elements(response, "table")

# returns a 23-element Vector of dataframes
broadcast(TidierVest.html_table, tables)
```

Edits: removed unnecessary comment after broadcast()