### PR TITLE
grant write perms in yml for doc deployment

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -2,7 +2,7 @@ name: Documentation
 on:
   push:
     branches:
-      - master
+      - main
     tags: '*'
   pull_request:
 jobs:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.9'
+          version: '1.11'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -19,3 +19,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
         run: julia --project=docs/ docs/make.jl
+permissions:
+  contents: write  # Required for authenticating with `GITHUB_TOKEN`
+  pull-requests: read  # Required for `push_preview=true`
+  statuses: write  # Optional, used to report documentation build statuses


### PR DESCRIPTION
Hi!

As per Karandeeps' suggestion in the Slack thread, I added a permissions entry to Documentation.yml the way Documenter.jl's [manual recommends](https://documenter.juliadocs.org/stable/man/hosting/#Permissions). 

While doing that, I also saw that the push branch's name was listed as `master` when this repo actually uses `main`, so I changed that too. 

Also, the Julia version for doc building was being given as 1.9 - I don't see any reason to use an older version for documentation building, so I changed that to 1.11, since newer versions have better compile and loading times. Let me know if there's a reason to use v1.9 though, I can revert that particular commit. 

